### PR TITLE
Fix potential typo update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN echo 0
 RUN curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 RUN apt-get install -y nodejs
 RUN npm install -g jest
-RUN npm install -g jest-json-repoter
+RUN npm install -g jest-json-reporter
 COPY registry/javascript/packages /packages
 COPY registry/javascript/template /template
 


### PR DESCRIPTION
Is the installation of 
jest-json-repoter and not jest-json-reporter) intentional?

For some reason the original author of the jest-json-reporter-package also added jest-json-repoter.
![image](https://github.com/user-attachments/assets/f81f1a18-51d9-4ce7-9ed2-62ae941a8a71)
